### PR TITLE
[ENG-168] Correction to bitwise opperation constant.

### DIFF
--- a/Entity/CacheRepository.php
+++ b/Entity/CacheRepository.php
@@ -34,7 +34,7 @@ class CacheRepository extends CommonRepository
 
     const SCOPE_GLOBAL      = 1;
 
-    const SCOPE_UTM_SOURCE  = 3;
+    const SCOPE_UTM_SOURCE  = 4;
 
     /** @var PhoneNumberHelper */
     protected $phoneHelper;


### PR DESCRIPTION
This prevented multiple sends to a client because of incorrect
duplicate checking. Global scope was being limited by UTM Source by
mistake.