### PR TITLE
[ENG-240] YAML response parse bug

### DIFF
--- a/Model/ApiPayloadResponse.php
+++ b/Model/ApiPayloadResponse.php
@@ -244,7 +244,10 @@ class ApiPayloadResponse
                     break;
 
                 case 'yaml':
-                    $hierarchy = Yaml::parse($data);
+                    $yaml = Yaml::parse($data, true);
+                    if (is_array($yaml) || is_object($yaml)) {
+                        $hierarchy = $yaml;
+                    }
                     break;
             }
         } catch (\Exception $e) {


### PR DESCRIPTION
Fixes Yaml parsing, and lowers the priority on auto detection so that YAML is after HTML/TEXT by default.