### PR TITLE
Improvement to client error validation

### DIFF
--- a/Model/ApiPayloadOperation.php
+++ b/Model/ApiPayloadOperation.php
@@ -37,7 +37,7 @@ class ApiPayloadOperation
     /** @var array */
     protected $responseExpected;
 
-    /** @var array */
+    /** @var string */
     protected $successDefinition;
 
     /** @var array */
@@ -104,7 +104,7 @@ class ApiPayloadOperation
         $this->name              = !empty($operation->name) ? $operation->name : $this->id;
         $this->request           = isset($operation->request) ? $operation->request : [];
         $this->responseExpected  = isset($operation->response) ? $operation->response : [];
-        $this->successDefinition = isset($operation->response->success->definition) ? $operation->response->success->definition : [];
+        $this->successDefinition = isset($operation->response->success->definition) ? $operation->response->success->definition : null;
         $this->tokenHelper       = $tokenHelper;
         $this->test              = $test;
         $this->updatePayload     = $updatePayload;

--- a/Model/ApiPayloadResponse.php
+++ b/Model/ApiPayloadResponse.php
@@ -36,7 +36,7 @@ class ApiPayloadResponse
     /** @var bool */
     protected $test;
 
-    /** @var array */
+    /** @var string */
     protected $successDefinition;
 
     /** @var bool */
@@ -404,7 +404,7 @@ class ApiPayloadResponse
             }
 
             // If there is no success definition, than do the default test of a 200 ok status check.
-            if (!$this->successDefinition) {
+            if (empty($this->successDefinition) || in_array($this->successDefinition, ['null', '[]'])) {
                 if (!$this->responseActual['status'] || 200 != $this->responseActual['status']) {
                     throw new ContactClientException(
                         'Status code is not 200. Default validation failure.',
@@ -414,9 +414,7 @@ class ApiPayloadResponse
                         true
                     );
                 }
-            }
-
-            if (!empty($this->successDefinition) && 'null' !== $this->successDefinition) {
+            } else {
                 // Standard success definition validation.
                 $filter = new FilterHelper();
                 try {

--- a/Model/ApiPayloadResponse.php
+++ b/Model/ApiPayloadResponse.php
@@ -392,10 +392,14 @@ class ApiPayloadResponse
                 );
             }
 
-            // Always consider a 500 to be an error.
-            if (isset($this->responseActual['status']) && 500 == $this->responseActual['status']) {
+            // Always consider a 5xx to be an error.
+            if (
+                is_int($this->responseActual['status'])
+                && $this->responseActual['status'] >= 500
+                && $this->responseActual['status'] < 600
+            ) {
                 throw new ContactClientException(
-                    'Client responded with a 500 server error code.',
+                    'Client responded with a '.$this->responseActual['status'].' server error code.',
                     0,
                     null,
                     Stat::TYPE_ERROR,


### PR DESCRIPTION
Via logs I’ve found a lot of 504s, 524s, and similar coming from
clients that aren’t being called “error” statuses. As a result we’re
not re-sending the leads, when we should since the lead might not have
been processed.