### PR TITLE
[ENG-448] fixes persist issue

### DIFF
--- a/Entity/Cache.php
+++ b/Entity/Cache.php
@@ -84,7 +84,7 @@ class Cache
      */
     public function __construct()
     {
-        $this->dateAdded = new \Datetime();
+        $this->dateAdded = new \DateTime();
     }
 
     /**

--- a/Entity/Event.php
+++ b/Entity/Event.php
@@ -67,7 +67,7 @@ class Event
      */
     public function __construct()
     {
-        $this->dateAdded = new \Datetime();
+        $this->dateAdded = new \DateTime();
         $this->type      = 'undefined';
     }
 

--- a/Entity/Stat.php
+++ b/Entity/Stat.php
@@ -112,7 +112,7 @@ class Stat
     /** @var int $id */
     private $id;
 
-    /** @var integer $contactClientId */
+    /** @var int $contactClientId */
     private $contactClientId;
 
     /** @var string $type */
@@ -344,7 +344,7 @@ class Stat
      */
     public function setContactClient(ContactClient $contactClient)
     {
-        $this->contactClient = $contactClient;
+        $this->contactClient   = $contactClient;
         $this->contactClientId = $contactClient->getId();
 
         return $this;

--- a/Entity/Stat.php
+++ b/Entity/Stat.php
@@ -112,8 +112,8 @@ class Stat
     /** @var int $id */
     private $id;
 
-    /** @var ContactClient $contactClient */
-    private $contactClient;
+    /** @var integer $contactClientId */
+    private $contactClientId;
 
     /** @var string $type */
     private $type;
@@ -130,6 +130,9 @@ class Stat
     /** @var string $utmSource */
     private $utm_source;
 
+    /** @var ContactClient */
+    private $contactClient = null;
+
     /**
      * @param ORM\ClassMetadata $metadata
      */
@@ -142,9 +145,7 @@ class Stat
 
         $builder->addId();
 
-        $builder->createManyToOne('contactClient', 'ContactClient')
-            ->addJoinColumn('contactclient_id', 'id', true, false, null)
-            ->build();
+        $builder->addNamedField('contactClientId', 'integer', 'contactclient_id');
 
         $builder->addField('type', 'string');
 
@@ -189,21 +190,21 @@ class Stat
     }
 
     /**
-     * @return mixed
+     * @return int
      */
-    public function getContactClient()
+    public function getContactClientId()
     {
-        return $this->contactClient;
+        return $this->contactClientId;
     }
 
     /**
-     * @param mixed $contactClient
+     * @param int $contactClientId
      *
      * @return Stat
      */
-    public function setContactClient($contactClient)
+    public function setContactClientId($contactClientId)
     {
-        $this->contactClient = $contactClient;
+        $this->contactClientId = $contactClientId;
 
         return $this;
     }
@@ -322,6 +323,29 @@ class Stat
     public function setUtmSource($utmSource)
     {
         $this->utm_source = $utmSource;
+
+        return $this;
+    }
+
+    /**
+     * @return ContactClient|int
+     */
+    public function getContactClient()
+    {
+        return isset($this->contactClient)
+            ? $this->contactClient
+            : $this->contactClientId;
+    }
+
+    /**
+     * @param ContactClient $contactClient
+     *
+     * @return $this
+     */
+    public function setContactClient(ContactClient $contactClient)
+    {
+        $this->contactClient = $contactClient;
+        $this->contactClientId = $contactClient->getId();
 
         return $this;
     }

--- a/Model/Schedule.php
+++ b/Model/Schedule.php
@@ -27,7 +27,7 @@ class Schedule
     /** @var \DateTimeZone */
     protected $timezone;
 
-    /** @var \Datetime $now */
+    /** @var \DateTime $now */
     protected $now;
 
     /** @var ContactClient $contactClient */
@@ -377,7 +377,7 @@ class Schedule
     }
 
     /**
-     * @return \Datetime
+     * @return \DateTime
      */
     public function getNow()
     {
@@ -392,7 +392,7 @@ class Schedule
     public function setNow(\DateTime $now = null)
     {
         if (!$now) {
-            $now = new \Datetime();
+            $now = new \DateTime();
         }
 
         $this->now = $now;


### PR DESCRIPTION
[2018-08-08 21:17:43] mautic.ERROR: CAMPAIGN: A new entity was found through the relationship 'MauticPlugin\MauticContactClientBundle\Entity\Stat#contactClient' that was not configured to cascade persist operations for entity: MauticPlugin\MauticContactClientBundle\Entity\ContactClient with ID #49. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist  this association in the mapping for example @ManyToOne(..,cascade={"persist"}). [] []
[2018-08-08 21:17:44] mautic.ERROR: CAMPAIGN: The EntityManager is closed. [] []

removed ManyToOne relationship, rcreated as a named field, and added setter for BC, getter unused, but added for convenience. 
ContactClientModel line 222 is cause, although not certain which caller. I would guess FilePayload line 870