### PR TITLE
[ENG-692] re-order validate tests 

### DIFF
--- a/Model/ApiPayloadResponse.php
+++ b/Model/ApiPayloadResponse.php
@@ -490,8 +490,7 @@ class ApiPayloadResponse
                 }
             }
 
-            if (!$this->valid && !isset($e))
-            {
+            if (!$this->valid && !isset($e)) {
                 throw new ContactClientException(
                     'Failed validation: '.implode(', ', $filter->getErrors()),
                     0,


### PR DESCRIPTION
so error codes come after success check for when success is expected to be an error like sleepnumber oracle implementations