### PR TITLE
[ENG-853] Corrections to Auto-Retry

### DIFF
--- a/Assets/json/api_payload.json
+++ b/Assets/json/api_payload.json
@@ -317,7 +317,7 @@
           "propertyOrder": 11,
           "type": "boolean",
           "format": "checkbox",
-          "default": false
+          "default": true
         },
         "verify": {
           "title": "Verify SSL",

--- a/Model/ApiPayloadResponse.php
+++ b/Model/ApiPayloadResponse.php
@@ -409,7 +409,7 @@ class ApiPayloadResponse
                             0,
                             null,
                             Stat::TYPE_REJECT,
-                            true
+                            false
                         );
                     }
                 }

--- a/Model/FilePayload.php
+++ b/Model/FilePayload.php
@@ -844,7 +844,8 @@ class FilePayload
                         'This contact appears to have been deleted: '.$contactId,
                         Codes::HTTP_GONE,
                         null,
-                        Stat::TYPE_REJECT
+                        Stat::TYPE_REJECT,
+                        false
                     );
                 }
 
@@ -927,7 +928,8 @@ class FilePayload
                     'Contact must be defined.',
                     Codes::HTTP_GONE,
                     null,
-                    Stat::TYPE_REJECT
+                    Stat::TYPE_REJECT,
+                    false
                 );
             }
 

--- a/Model/Schedule.php
+++ b/Model/Schedule.php
@@ -204,7 +204,8 @@ class Schedule
                         'This contact client does not allow contacts on a '.$this->now->format('l').'.',
                         0,
                         null,
-                        Stat::TYPE_SCHEDULE
+                        Stat::TYPE_SCHEDULE,
+                        false
                     );
                 } elseif ($returnHours) {
                     return $hours[$day];
@@ -294,7 +295,8 @@ class Schedule
                             'This contact client does not allow contacts on the date '.$dateString.'.',
                             0,
                             null,
-                            Stat::TYPE_SCHEDULE
+                            Stat::TYPE_SCHEDULE,
+                            false
                         );
                     }
                 }
@@ -325,7 +327,8 @@ class Schedule
                 'This client has reached the maximum number of files they can receive per day.',
                 0,
                 null,
-                Stat::TYPE_SCHEDULE
+                Stat::TYPE_SCHEDULE,
+                false
             );
         }
 
@@ -371,7 +374,8 @@ class Schedule
                             'This contact client does not allow contacts during this time of day.',
                             0,
                             null,
-                            Stat::TYPE_SCHEDULE
+                            Stat::TYPE_SCHEDULE,
+                            false
                         );
                     }
                     if ($returnRange) {


### PR DESCRIPTION
Specifically for off schedule situations.

Apparently we’ve been auto-retrying those based on the API payload setting. That’s not accurate because we now have an explicit Queue Off Schedule option which should supersede that checkbox.

The workaround to avoid this scenario is to uncheck that checkbox, but this PR resolves the issue by setting off schedule events as not retrying by default. That is overrides by the “Queue Off Schedule” switch, if flipped.