### PR TITLE
[ENG-867] Trim field value before checking for empty/null

### DIFF
--- a/Model/ApiPayloadRequest.php
+++ b/Model/ApiPayloadRequest.php
@@ -302,7 +302,7 @@ class ApiPayloadRequest
                     }
                 }
             }
-            if (null === $value || '' === $value) {
+            if (null === $value || '' === trim($value)) {
                 // The field value is empty and not 0/false.
                 if (true === (isset($field->required) ? $field->required : false)) {
                     // The field is required. Abort.


### PR DESCRIPTION
Original Ticket/Request:
> The situation is that we have required fields, but the evaluated tokens result in an empty " " (space) result, because there was a space between the tokens. The app considers this a valid value (because it's not completely empty) and thus doesn't mark that as missing a required field.
> When we mark a field as "required" that should mean that some non-empty whitespace character must exist there. 
> Examples:
> "" - should be considered empty
> " " - should be considered empty
> "     " - should be considered empty
> "0" - should NOT be considered empty
> "        0" - should NOT be considered empty
> "(anything else here)" - should NOT be considered empty

As you can see from the code change, simply trimming the value should remove the suspect empty space, causing a " " to get converted to "" triggering the existing "Required Field" exception.