### PR TITLE
[ENG-941] Improve client newrelic support.

### DIFF
--- a/Integration/ClientIntegration.php
+++ b/Integration/ClientIntegration.php
@@ -358,7 +358,7 @@ class ClientIntegration extends AbstractIntegration
             $this->valid = $this->payloadModel->getValid();
 
             if ($this->valid) {
-                $this->statType = Stat::TYPE_CONVERTED;
+                $this->setStatType(Stat::TYPE_CONVERTED);
             }
         } catch (\Exception $e) {
             $this->handleException($e);
@@ -416,7 +416,7 @@ class ClientIntegration extends AbstractIntegration
      */
     private function addTrace($parameter, $value)
     {
-        if (function_exists('newrelic_add_custom_parameter')) {
+        if ($parameter && function_exists('newrelic_add_custom_parameter')) {
             call_user_func('newrelic_add_custom_parameter', $parameter, $value);
         }
     }
@@ -803,7 +803,7 @@ class ClientIntegration extends AbstractIntegration
 
             // We will persist exception information to logs/stats.
             if ($exception->getStatType()) {
-                $this->statType = $exception->getStatType();
+                $this->setStatType($exception->getStatType());
                 $this->setLogs($this->statType, 'status');
             }
             $errorData = $exception->getData();
@@ -1055,8 +1055,7 @@ class ClientIntegration extends AbstractIntegration
 
         // Stats - contactclient_stats
         $errors         = $this->getLogs('error');
-        $this->statType = !empty($this->statType) ? $this->statType : Stat::TYPE_ERROR;
-        $this->addTrace('contactClientStatType', $this->statType);
+        $this->setStatType(!empty($this->statType) ? $this->statType : Stat::TYPE_ERROR);
         $message = '';
         if ($this->valid) {
             $statLevel = 'INFO';
@@ -1575,6 +1574,7 @@ class ClientIntegration extends AbstractIntegration
     public function setStatType($statType = '')
     {
         $this->statType = $statType;
+        $this->addTrace('contactClientStatType', $this->statType);
 
         return $this;
     }

--- a/Integration/ClientIntegration.php
+++ b/Integration/ClientIntegration.php
@@ -369,6 +369,10 @@ class ClientIntegration extends AbstractIntegration
             if ($operationLogs) {
                 $this->setLogs($operationLogs, 'operations');
             }
+            $lastOp = $this->payloadModel->getLastOp();
+            if ($lastOp) {
+                $this->addTrace('contactClientLastOp', $lastOp);
+            }
         }
 
         $this->updateContact();

--- a/Integration/ClientIntegration.php
+++ b/Integration/ClientIntegration.php
@@ -316,6 +316,7 @@ class ClientIntegration extends AbstractIntegration
 
         try {
             $this->validateClient($client, $force);
+            $this->clearTraces();
             $this->addTrace('contactClient', $this->contactClient->getName());
             $this->addTrace('contactClientId', $this->contactClient->getId());
 
@@ -422,6 +423,40 @@ class ClientIntegration extends AbstractIntegration
     {
         if ($parameter && function_exists('newrelic_add_custom_parameter')) {
             call_user_func('newrelic_add_custom_parameter', $parameter, $value);
+        }
+    }
+
+    /**
+     * If available add a noticed exception to NewRelic to aid in debugging.
+     *
+     * @param      $message
+     * @param null $exception
+     */
+    private function addError($message, $exception = null)
+    {
+        if ($message && function_exists('newrelic_notice_error')) {
+            call_user_func('newrelic_notice_error', $message, $exception);
+        }
+    }
+
+    /**
+     * Clears any NewRelic trace params we use here to prevent occlusion as there can be multiple clients per session.
+     */
+    private function clearTraces()
+    {
+        $parameters = [
+            'contactClientStatType',
+            'contactClient',
+            'contactClientId',
+            'contactClientLastOp',
+            'contactClientContactId',
+            'campaign',
+            'campaignId',
+            'event',
+            'eventId',
+        ];
+        foreach ($parameters as $trace) {
+            $this->addTrace($trace, null);
         }
     }
 

--- a/Integration/ClientIntegration.php
+++ b/Integration/ClientIntegration.php
@@ -849,27 +849,18 @@ class ClientIntegration extends AbstractIntegration
             if ($errorData) {
                 $this->setLogs($errorData, $exception->getStatType());
             }
+
+            $message = 'ContactClient '.$this->contactClient->getType().' Error '.($this->contactClient ? $this->contactClient->getId() : 'NA');
         } elseif ($exception instanceof ConnectException) {
-            if (function_exists('newrelic_notice_error')) {
-                call_user_func(
-                    'newrelic_notice_error',
-                    'ContactClient Connection Error '.($this->contactClient ? $this->contactClient->getId() : 'NA'),
-                    $exception
-                );
-            }
+            $message = 'ContactClient Connection Error '.($this->contactClient ? $this->contactClient->getId() : 'NA');
         } else {
-            if (function_exists('newrelic_notice_error')) {
-                call_user_func(
-                    'newrelic_notice_error',
-                    'ContactClient Integration Error '.($this->contactClient ? $this->contactClient->getId() : 'NA'),
-                    $exception
-                );
-            }
             // Unexpected issue with the Client plugin.
             $this->logIntegrationError($exception, $this->contact);
+            $message = 'ContactClient Integration Error '.($this->contactClient ? $this->contactClient->getId() : 'NA');
         }
         $this->setLogs($exception->getMessage(), 'error');
         $this->setLogs($this->retry, 'retry');
+        $this->addError($message, $exception);
     }
 
     /**

--- a/Integration/ClientIntegration.php
+++ b/Integration/ClientIntegration.php
@@ -239,6 +239,12 @@ class ClientIntegration extends AbstractIntegration
                     }
                 } catch (\Exception $e) {
                 }
+                if (isset($this->event['name']) && !empty($this->event['name'])) {
+                    $this->addTrace('event', $this->event['name']);
+                }
+                if (isset($this->event['id']) && $this->event['id']) {
+                    $this->addTrace('eventId', $this->event['id']);
+                }
             }
         }
 

--- a/Model/ApiPayload.php
+++ b/Model/ApiPayload.php
@@ -109,6 +109,9 @@ class ApiPayload
     /** @var int Starting operation ID. */
     protected $start = 0;
 
+    /** @var mixed Current operation ID/name. */
+    protected $op;
+
     /**
      * ApiPayload constructor.
      *
@@ -429,6 +432,7 @@ class ApiPayload
         $opsRemaining  = count($this->payload->operations);
 
         foreach ($this->payload->operations as $id => &$operation) {
+            $this->op = $id.(!empty($operation['name']) ? ' '.$operation['name'] : '');
             if ($id < $this->start) {
                 // Running a pre-auth attempt with step/s to be skipped at the beginning.
                 continue;
@@ -693,6 +697,16 @@ class ApiPayload
         } else {
             $this->logs[] = $value;
         }
+    }
+
+    /**
+     * Get the last Operation ID that was assembled/attempted.
+     *
+     * @return mixed
+     */
+    public function getLastOp()
+    {
+        return $this->op;
     }
 
     /**

--- a/Model/FilePayload.php
+++ b/Model/FilePayload.php
@@ -169,6 +169,9 @@ class FilePayload
     /** @var UtmSourceHelper */
     protected $utmSourceHelper;
 
+    /** @var mixed Current operation ID/name. */
+    protected $op;
+
     /**
      * FilePayload constructor.
      *
@@ -1372,6 +1375,7 @@ class FilePayload
         $successCount = 0;
         if (isset($this->payload->operations)) {
             foreach ($this->payload->operations as $type => $operation) {
+                $this->op = $type;
                 if (is_object($operation)) {
                     ++$attemptCount;
                     $result = false;
@@ -1857,6 +1861,16 @@ class FilePayload
         }
 
         return array_merge($fileLogs, $this->logs);
+    }
+
+    /**
+     * Get the last Operation ID that was assembled/attempted.
+     *
+     * @return mixed
+     */
+    public function getLastOp()
+    {
+        return $this->op;
     }
 
     /**


### PR DESCRIPTION
* Cleans out params when a new contact is being sent.
* Adds event name and ID params.
* Adds lastOp (last operation performed) so that we know which operation had the error without jumping into logs.
* Adds external client errors as noticed exceptions so that clients erroring out cause more of a fuss, and analytical data can be reported in NR dashboards.