### PR TITLE
[ENG-950] Client: Cannot use object of type stdClass as array in Model/ApiPayload.php

### DIFF
--- a/Model/ApiPayload.php
+++ b/Model/ApiPayload.php
@@ -432,7 +432,7 @@ class ApiPayload
         $opsRemaining  = count($this->payload->operations);
 
         foreach ($this->payload->operations as $id => &$operation) {
-            $this->op = $id.(!empty($operation['name']) ? ' '.$operation['name'] : '');
+            $this->op = $id.(!empty($operation->name) ? ' '.$operation->name : '');
             if ($id < $this->start) {
                 // Running a pre-auth attempt with step/s to be skipped at the beginning.
                 continue;


### PR DESCRIPTION
**Please be sure you are submitting this against the _master_ branch.**

[//]: # This Pull Request (Place an 'X' for each):

| Risk Level                                | No | Low | High |
| ----------------------------------------- | -- | --- | ---- |
| Alters Lead Data?                         |    |     |      |
| Schema Change?                            |    |     |      |
| Adds A Query or Modifies Existing Query?  |    |     |      |
| Adds or Modifies Existing Auto-Enhancer?  |    |     |      |
| Modifies Ingestion Process?               |    |     |      |
| Modifies sendContact Data?                |    |     |      |


[//]: # ( Required: )
#### Description:
Fixes a bug where $operation was being used as an array instead of as an object.