### PR TITLE
[ENG-601] override Contact Clients Event Name if Blank or Wrong Client Name

### DIFF
--- a/Integration/ClientIntegration.php
+++ b/Integration/ClientIntegration.php
@@ -1372,11 +1372,13 @@ class ClientIntegration extends AbstractIntegration
                             'tooltip'  => 'mautic.contactclient.integration.client.tooltip',
                             // Auto-set the integration name based on the client.
                             'onchange' => "var client = mQuery('#campaignevent_properties_config_contactclient:first'),".
-                                "    eventName = mQuery('#campaignevent_name');".
-                                "    var previousClient = false;".
-                                "    mQuery('#campaignevent_properties_config_contactclient option').each(function(ii, i) {".
-                                "        if (i.innerText == eventName.val()) { previousClient = true; }".
-                                "    });".
+                                '    eventName = mQuery("#campaignevent_name");'.
+                                '    var previousClient = false;'.
+                                '    mQuery("#campaignevent_properties_config_contactclient option").each(function(ii, i) {'.
+                                '        if (i.innerText == eventName.val()) {'.
+                                '            previousClient = true;'.
+                                '        }'.
+                                '    });'.
                                 'if (client.length && client.val() && eventName.length && (!eventName.val() || previousClient)) {'.
                                 '    eventName.val(client.find("option:selected:first").text().trim());'.
                                 '}',

--- a/Integration/ClientIntegration.php
+++ b/Integration/ClientIntegration.php
@@ -1373,7 +1373,11 @@ class ClientIntegration extends AbstractIntegration
                             // Auto-set the integration name based on the client.
                             'onchange' => "var client = mQuery('#campaignevent_properties_config_contactclient:first'),".
                                 "    eventName = mQuery('#campaignevent_name');".
-                                'if (client.length && client.val() && eventName.length) {'.
+                                "    var previousClient = false;".
+                                "    mQuery('#campaignevent_properties_config_contactclient option').each(function(ii, i) {".
+                                "        if (i.innerText == eventName.val()) { previousClient = true; }".
+                                "    });".
+                                'if (client.length && client.val() && eventName.length && (!eventName.val() || previousClient)) {'.
                                 '    eventName.val(client.find("option:selected:first").text().trim());'.
                                 '}',
                         ],


### PR DESCRIPTION
…om a previous client selection. Or blank.

**Please be sure you are submitting this against the _master_ branch.**

[//]: # This Pull Request (Place an 'X' for each):

| Risk Level                                | No | Low | High |
| ----------------------------------------- | -- | --- | ---- |
| Alters Lead Data?                         |  x |     |      |
| Schema Change?                            |  x |     |      |
| Adds A Query or Modifies Existing Query?  |  x |     |      |
| Adds or Modifies Existing Auto-Enhancer?  |  x |     |      |
| Modifies Ingestion Process?               |  x |     |      |
| Modifies sendContact Data?                |  x |     |      |


[//]: # ( Required: )
#### Description:
> Modify existing Javascript/OnChange event to only insert Client Name as Event Name if input is blank or is the Name of another client in list (from a previous selection).