### PR TITLE
[ENG-1025] Improve newrelic client error accuracy.

### DIFF
--- a/Integration/ClientIntegration.php
+++ b/Integration/ClientIntegration.php
@@ -376,8 +376,8 @@ class ClientIntegration extends AbstractIntegration
         $this->test          = $test;
 
         try {
-            $this->validateClient($client, $force);
             $this->clearTraces();
+            $this->validateClient($client, $force);
             $this->addTrace('contactClient', $this->contactClient->getName());
             $this->addTrace('contactClientId', $this->contactClient->getId());
 
@@ -486,7 +486,7 @@ class ClientIntegration extends AbstractIntegration
             'eventId',
         ];
         foreach ($parameters as $trace) {
-            $this->addTrace($trace, null);
+            $this->addTrace($trace, 'NA');
         }
     }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _master_ branch.**

[//]: # This Pull Request (Place an 'X' for each):

| Risk Level                                | No | Low | High |
| ----------------------------------------- | -- | --- | ---- |
| Alters Lead Data?                         |  X  |     |      |
| Schema Change?                            | X   |     |      |
| Adds A Query or Modifies Existing Query?  |  X  |     |      |
| Adds or Modifies Existing Auto-Enhancer?  |  X  |     |      |
| Modifies Ingestion Process?               |  X  |     |      |
| Modifies sendContact Data?                |  X  |     |      |


[//]: # ( Required: )
#### Description:
The newrelic provided stats sometimes get a little fuzzy when there's a client error in large quantities. An error with one client appears to affect others, but this is inaccurate, and likely due to how newrelic_add_custom_parameter works under the C code. If we null out values with a string instead of "null" the issue should go away according to one NR support thread. We'll give that a try with the next release, since there's no risk to doing so, and it's a minor change.